### PR TITLE
Fix logging of variable's type instead of the value

### DIFF
--- a/EnLitenTelegramBot.Worker/Models/BotConfiguration.cs
+++ b/EnLitenTelegramBot.Worker/Models/BotConfiguration.cs
@@ -6,6 +6,6 @@ namespace EnLitenTelegramBot.Worker.Models
         public string Token { get; set; }
         public string UpdatesMethod { get; set; }
         public string SendMethod { get; set; }
-        public int HighestRespondedMessageId { get; set; }
+        public int HighestRespondedUpdateId { get; set; }
     }
 }

--- a/EnLitenTelegramBot.Worker/Models/IBot.cs
+++ b/EnLitenTelegramBot.Worker/Models/IBot.cs
@@ -5,7 +5,7 @@ namespace EnLitenTelegramBot.Worker.Models
 {
     public interface IBot
     {
-        int HighestRespondedMessageId { get; set; }
+        int HighestRespondedUpdateId { get; set; }
         string ApiUrl { get; }
         string UpdatesUrl { get; }
         string SendUrl { get; }

--- a/EnLitenTelegramBot.Worker/Models/TelegramBot.cs
+++ b/EnLitenTelegramBot.Worker/Models/TelegramBot.cs
@@ -8,9 +8,9 @@ namespace EnLitenTelegramBot.Worker.Models
         public TelegramBot(BotConfiguration botConfiguration)
         {
             _botConfiguration = botConfiguration;
-            HighestRespondedMessageId = _botConfiguration.HighestRespondedMessageId;
+            HighestRespondedUpdateId = _botConfiguration.HighestRespondedUpdateId;
         }
-        public int HighestRespondedMessageId { get; set; }
+        public int HighestRespondedUpdateId { get; set; }
         public string ApiUrl => $"https://api.telegram.org/bot{ _botConfiguration.Token }";
         public string UpdatesUrl => $"{ ApiUrl }/{ _botConfiguration.UpdatesMethod }";
         public string SendUrl => $"{ ApiUrl }/{ _botConfiguration.SendMethod }";

--- a/EnLitenTelegramBot.Worker/Services/TelegramBotService.cs
+++ b/EnLitenTelegramBot.Worker/Services/TelegramBotService.cs
@@ -17,7 +17,6 @@ namespace EnLitenTelegramBot.Worker.Services
         private readonly IBot _bot;
         private readonly ILogger _logger;
         private readonly IHttpClientFactory _httpClientFactory;
-        private const string GET_UPDATES_PATH = "getUpdates";
 
         public TelegramBotService(ILogger<TelegramBotService> logger, IBot bot, IHttpClientFactory httpClientFactory)
         {
@@ -54,10 +53,10 @@ namespace EnLitenTelegramBot.Worker.Services
                 _logger.LogError(e.ToString());
             }
 
-            _logger.LogInformation($"Returned payload is: { updates }");
+            _logger.LogInformation($"Returned payload is: { JsonSerializer.Serialize(updates) }");
 
             // return only updates to which it hasn't been responded
-            return updates.Where(update => update.Message.MessageId > _bot.HighestRespondedMessageId);
+            return updates.Where(update => update.UpdateId > _bot.HighestRespondedUpdateId);
         }
 
         /// <summary>
@@ -66,7 +65,7 @@ namespace EnLitenTelegramBot.Worker.Services
         /// <param name="chatId"> ID of the chat to which the message will be sent</param>
         /// <param name="text"> Text which will be sent to the chat</param>
         /// <returns></returns>
-        public async Task SendMessage(int chatId, string text, int messageId)
+        public async Task SendMessage(int chatId, string text, int updateId)
         {
             var httpClient = _httpClientFactory.CreateClient();
 
@@ -95,9 +94,9 @@ namespace EnLitenTelegramBot.Worker.Services
                 _logger.LogError(e.ToString());
             }
             // update the highest responed messageId
-            _bot.HighestRespondedMessageId = messageId > _bot.HighestRespondedMessageId
-                ? messageId
-                : _bot.HighestRespondedMessageId;
+            _bot.HighestRespondedUpdateId = updateId > _bot.HighestRespondedUpdateId
+                ? updateId
+                : _bot.HighestRespondedUpdateId;
         }
     }
 }

--- a/EnLitenTelegramBot.Worker/Worker.cs
+++ b/EnLitenTelegramBot.Worker/Worker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EnLitenTelegramBot.Worker.Models;
@@ -46,7 +47,7 @@ namespace EnLitenTelegramBot.Worker
                     _logger.LogCritical(e.StackTrace);
                 }
                 
-                _logger.LogInformation($"Returned updates: { updates }");
+                _logger.LogInformation($"Returned updates: { JsonSerializer.Serialize(updates) }");
                 #endregion
 
                 #region RespondToUpdates
@@ -57,7 +58,7 @@ namespace EnLitenTelegramBot.Worker
                     {
                         await _botService.SendMessage(update.Message.Chat.Id, 
                             "How <i><b>you</b></i> doin'?", 
-                            update.Message.MessageId);
+                            update.UpdateId);
                     }
                     catch(HttpRequestException e)
                     {

--- a/EnLitenTelegramBot.Worker/appsettings.json
+++ b/EnLitenTelegramBot.Worker/appsettings.json
@@ -10,6 +10,6 @@
     "Token": "1095210165:AAEAIQQgj8ikg9oIiObjyFBJg8KAQ6SuR3s",
     "UpdatesMethod":  "getUpdates",
     "SendMethod": "sendMessage",
-    "HighestRespondedMessageId": 32
+    "HighestRespondedUpdateId": 907889273
   }
 }


### PR DESCRIPTION
Fixed the logging issue, and updated message response rule
to use update_id property instead of message_id property.